### PR TITLE
Remove DeepSite references and center login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ colorFrom: purple
 colorTo: yellow
 sdk: static
 pinned: false
-tags:
-  - deepsite
 ---
 
 Check out the configuration reference at https://huggingface.co/docs/hub/spaces-config-reference

--- a/index.html
+++ b/index.html
@@ -845,5 +845,5 @@
             }, 2500);
         }
     </script>
-<p style="border-radius: 8px; text-align: center; font-size: 12px; color: #fff; margin-top: 16px;position: fixed; left: 8px; bottom: 8px; z-index: 10; background: rgba(0, 0, 0, 0.8); padding: 4px 8px;">Made with <img src="https://enzostvs-deepsite.hf.space/logo.svg" alt="DeepSite Logo" style="width: 16px; height: 16px; vertical-align: middle;display:inline-block;margin-right:3px;filter:brightness(0) invert(1);"><a href="https://enzostvs-deepsite.hf.space" style="color: #fff;text-decoration: underline;" target="_blank" >DeepSite</a> - 🧬 <a href="https://enzostvs-deepsite.hf.space?remix=qdj6rvaf9e/ai-burns-assessment" style="color: #fff;text-decoration: underline;" target="_blank" >Remix</a></p></body>
+</body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
-	padding: 2rem;
-	font-family: -apple-system, BlinkMacSystemFont, "Arial", sans-serif;
+        padding: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Arial", sans-serif;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- strip DeepSite branding and remove related tag
- ensure login page displays centered

## Testing
- `grep -R "deepsite" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_685da058f3a083338079fc211655fc35